### PR TITLE
Move ByteBufferBytesReference to BytesArray

### DIFF
--- a/src/main/java/org/elasticsearch/thrift/ThriftRestRequest.java
+++ b/src/main/java/org/elasticsearch/thrift/ThriftRestRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.thrift;
 
-import org.elasticsearch.common.bytes.ByteBufferBytesReference;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.ImmutableList;
@@ -95,7 +94,7 @@ public class ThriftRestRequest extends org.elasticsearch.rest.RestRequest {
         if (!request.isSetBody()) {
             return BytesArray.EMPTY;
         }
-        return new ByteBufferBytesReference(request.bufferForBody());
+        return new BytesArray(request.getBody());
     }
 
     @Override


### PR DESCRIPTION
This commit https://github.com/elasticsearch/elasticsearch/commit/e8e71e323a97d92d0a76b745893930159b16c0f9 in elasticsearch moved `ByteBufferBytesReference` to test package. Actually, we probably could use a `BytesArray` instead of `ByteBufferBytesReference` in this transport plugin.
